### PR TITLE
Fix unnecessary allocations in distGauss!

### DIFF
--- a/src/DualTree01.jl
+++ b/src/DualTree01.jl
@@ -21,7 +21,7 @@ function distGauss!(restmp::Array{Float64, 1},
                     mainop=(-,),
                     diffop=(-,),
                     saturate::Bool=false,
-                    isX86Arch::Bool= (Base.Sys.ARCH in [:x86_64;])  )
+                    isX86Arch::Bool= (Base.Sys.ARCH == :x86_64)  )
   #
   # internal helper to for IR optimization to remove
 

--- a/src/DualTree01.jl
+++ b/src/DualTree01.jl
@@ -21,7 +21,7 @@ function distGauss!(restmp::Array{Float64, 1},
                     mainop=(-,),
                     diffop=(-,),
                     saturate::Bool=false,
-                    isX86Arch::Bool= (Base.Sys.ARCH == :x86_64)  )
+                    isX86Arch::Bool= (Base.Sys.ARCH === :x86_64)  )
   #
   # internal helper to for IR optimization to remove
 


### PR DESCRIPTION
This was actually a performance bottleneck in IIF.

Also, note that `isX86Arch` is not used.

Standard hex test:
Before:
 3.699988 seconds (1.78 M allocations: 90.311 MiB, 1.34% gc time)
After:
 2.668882 seconds (1.31 M allocations: 62.113 MiB, 0.94% gc time)